### PR TITLE
fix(sandbox): added check that the port is valid

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,13 +4,10 @@ root = true
 charset = utf-8
 end_of_line = lf
 indent_style = space
-indent_size = 4
+indent_size = 2
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.{js,ts}]
-indent_size = 2
+[*.{js,ts,jsx,tsx}]
 max_line_length = 100
 
-[*.{yml,yaml}]
-indent_size = 2

--- a/src/pages/SandboxPage/components/DaemonSettings/DaemonSettings.tsx
+++ b/src/pages/SandboxPage/components/DaemonSettings/DaemonSettings.tsx
@@ -8,6 +8,15 @@ interface DaemonSettingsProps {
   readonly onChange: (next: {host: string; port: string}) => void
 }
 
+const portIsValid = (port: string): boolean => {
+  const portNumber = Number(port)
+  if (isNaN(portNumber)) {
+    return false
+  }
+
+  return portNumber >= 1 && portNumber <= 65535
+}
+
 export function DaemonSettings({host, port, onChange}: DaemonSettingsProps) {
   const [localHost, setLocalHost] = useState(host)
   const [localPort, setLocalPort] = useState(port)
@@ -44,7 +53,7 @@ export function DaemonSettings({host, port, onChange}: DaemonSettingsProps) {
               const raw = e.target.value
               const next = raw.replace(/[^0-9]/g, "")
               setLocalPort(next)
-              if (next.length > 0) {
+              if (next.length > 0 && portIsValid(next)) {
                 onChange({host: localHost, port: next})
               }
             }}

--- a/src/pages/SandboxPage/components/DaemonSettings/DaemonSettings.tsx
+++ b/src/pages/SandboxPage/components/DaemonSettings/DaemonSettings.tsx
@@ -14,7 +14,7 @@ const portIsValid = (port: string): boolean => {
     return false
   }
 
-  return portNumber >= 1 && portNumber <= 65535
+  return portNumber >= 0 && portNumber <= 65535
 }
 
 export function DaemonSettings({host, port, onChange}: DaemonSettingsProps) {


### PR DESCRIPTION
If an incorrect port is specified, we will receive the error `SyntaxError: Failed to construct 'WebSocket': The URL 'ws://$host:$port' is invalid.`